### PR TITLE
:sparkles: feat: Adding the step-07

### DIFF
--- a/cloudshell_tutorial.md
+++ b/cloudshell_tutorial.md
@@ -342,6 +342,21 @@ The deployment process will create all necessary GCP resources, including GKE cl
 
 After deploying the infrastructure, you need to configure the Google Workspace admin user you identified in Step 5 with the necessary permissions:
 
+1. This should be the same user you specified during the Terraform configuration 
+- Remember that this user must have a valid email under your organization's domain (e.g., admin@domain.edu) 
+- This user will be responsible for managing labels in Google Drive
+
+<walkthrough-footnote>
+This is the same user account you identified in Step 5 and provided during the Terraform configuration. Now you'll grant it the specific permissions needed for label management operations required by the Sync to Cloud application.
+</walkthrough-footnote>
+
+<!-- #################### STEP 16 #################### -->
+<!-- #################### STEP 16 #################### -->
+
+## Configure Admin User Permissions
+
+After deploying the infrastructure, you need to configure the Google Workspace admin user you identified in Step 5 with the necessary permissions:
+
 1. This should be the same user you specified during the Terraform configuration
    - Remember that this user must have a valid email under your organization's domain (e.g., admin@domain.edu)
    - This user will be responsible for managing labels in Google Drive
@@ -350,8 +365,8 @@ After deploying the infrastructure, you need to configure the Google Workspace a
 This is the same user account you identified in Step 5 and provided during the Terraform configuration. Now you'll grant it the specific permissions needed for label management operations required by the Sync to Cloud application.
 </walkthrough-footnote>
 
-<!-- #################### STEP 16 #################### -->
-<!-- #################### STEP 16 #################### -->
+<!-- #################### STEP 17 #################### -->
+<!-- #################### STEP 17 #################### -->
 
 ## Create and Assign Label Management Role
 
@@ -370,8 +385,8 @@ The selected user needs specific permissions for managing labels:
 The "Manage Labels" permission allows the user to create, edit, and manage labels for data classification in Google Drive, which is essential for the Sync to Cloud service to identify and process files correctly.
 </walkthrough-footnote>
 
-<!-- #################### STEP 17 #################### -->
-<!-- #################### STEP 17 #################### -->
+<!-- #################### STEP 18 #################### -->
+<!-- #################### STEP 18 #################### -->
 
 ## Grant Domain-wide Delegation for Rclone Service Account
 
@@ -395,8 +410,8 @@ Now, you need to grant domain-wide delegation to the service accounts created by
 The Drive scope (`https://www.googleapis.com/auth/drive`) grants the Rclone Service Account full access to manage files in Google Drive, including creating, editing, moving, and deleting files and folders. This broad access is needed so Rclone can fully handle file transfers and move operations.
 </walkthrough-footnote>
 
-<!-- #################### STEP 18 #################### -->
-<!-- #################### STEP 18 #################### -->
+<!-- #################### STEP 19 #################### -->
+<!-- #################### STEP 19 #################### -->
 
 ## Grant Domain-wide Delegation for Worker Service Account
 
@@ -419,8 +434,8 @@ Next, configure domain-wide delegation for the Worker Service Account:
 The Worker Service Account needs the Drive scope (`https://www.googleapis.com/auth/drive`) to access and manage files in Google Drive, including reading files, updating metadata and labels, managing transfers, and coordinating with the Rclone service for efficient file processing.
 </walkthrough-footnote>
 
-<!-- #################### STEP 19 #################### -->
-<!-- #################### STEP 19 #################### -->
+<!-- #################### STEP 20 #################### -->
+<!-- #################### STEP 20 #################### -->
 
 ## Grant Domain-wide Delegation for API Service Account
 
@@ -443,48 +458,45 @@ Configure domain-wide delegation for the API Service Account:
 The API Service Account needs the Drive Labels readonly scope (`https://www.googleapis.com/auth/drive.admin.labels.readonly`) to view and read Drive labels and their assignments across your organization, which enables identifying files for transfer based on their labels.
 </walkthrough-footnote>
 
-<!-- #################### STEP 20 #################### -->
-<!-- #################### STEP 20 #################### -->
-
-## Assign Storage Admin Role to Worker Service Account
-
-You need to assign the Storage Admin role to the worker service account:
-
-1. Navigate to the [Google Workspace Admin Roles page](https://admin.google.com/ac/roles)
-2. Click on "Storage Admin"
-3. Click on "Admins"
-4. Click on "Assign service accounts"
-5. Add the worker service account:
-   ```
-   sa-sync-to-cloud-worker@<walkthrough-project-id/>.iam.gserviceaccount.com
-   ```
-
-<walkthrough-footnote>
-This service account permission will be used to access shared drives and give the "organizer" role to the rclone service account when transferring files, ensuring the service account has proper access to the shared drive to move files.
-</walkthrough-footnote>
-
 <!-- #################### STEP 21 #################### -->
 <!-- #################### STEP 21 #################### -->
 
 ## Grant BigQuery Permissions for Drive Inventory Report
 
-The Sync to Cloud application uses BigQuery Drive Inventory Report to identify and process files. You must grant specific permissions to the Worker Service Account in the Google Cloud project where your BigQuery Drive inventory dataset is located.
+The Sync to Cloud application uses BigQuery Drive Inventory Report to identify and process files. You must grant specific permissions to both the Worker and API Service Accounts in the Google Cloud project where your BigQuery Drive inventory dataset is located.
 
-1.  **Identify the Project ID**: Determine the Google Cloud Project ID that hosts your BigQuery Drive Inventory Report dataset.
-2.  **Navigate to IAM**: Go to the IAM & Admin page of the project containing the BigQuery dataset.
-3.  **Grant Access**:
-   - Click on "**GRANT ACCESS**".
-   - In the "**New principals**" field, add the Worker Service Account: `sa-sync-to-cloud-worker@<walkthrough-project-id/>.iam.gserviceaccount.com`
-   - Assign the role "**BigQuery Job User**" (`roles/bigquery.jobUser`). This role must be granted at the **project level**.
-   - Click "**ADD ANOTHER ROLE**".
-   - Assign the role "**BigQuery Data Viewer**" (`roles/bigquery.dataViewer`). This role can be granted at the **project level** or, for more fine-grained control, directly on the **dataset** containing your Drive inventory report.
-   - Click "**SAVE**".
+### Option 1: Use the Helper Script (Recommended)
+
+Run the helper script to get the exact commands you need:
+
+```sh
+./steps/07_grant_bigquery_permissions.sh <walkthrough-project-id/>
+```
+
+This script will:
+1. Read your BigQuery configuration from the terraform.tfvars file
+2. Generate the exact `gcloud` and `bq` commands you need to run
+3. Provide options for both project-level and dataset-level permissions
+4. Display the service account emails with your specific project ID
+
+### Option 2: Manual Configuration via Console
+
+1. **Identify the Project ID**: Determine the Google Cloud Project ID that hosts your BigQuery Drive Inventory Report dataset.
+2. **Navigate to IAM**: Go to the [IAM & Admin page](https://console.cloud.google.com/iam-admin/iam) of the project containing the BigQuery dataset.
+3. **Grant Access**: 
+- Click on "**GRANT ACCESS**". 
+- In the "**New principals**" field, add both service accounts: 
+- `sa-sync-to-cloud-worker@<walkthrough-project-id/>.iam.gserviceaccount.com` 
+- `sa-sync-to-cloud-api@<walkthrough-project-id/>.iam.gserviceaccount.com` 
+- Assign the role "**BigQuery Job User**" (`roles/bigquery.jobUser`). This role must be granted at the **project level**. 
+- Click "**ADD ANOTHER ROLE**". 
+- Assign the role "**BigQuery Data Viewer**" (`roles/bigquery.dataViewer`). This role can be granted at the **project level** or, for more fine-grained control, directly on the **dataset** containing your Drive inventory report. 
+- Click "**SAVE**".
 
 <walkthrough-footnote>
-These permissions allow the Worker Service Account to query and read data from your Drive inventory report in BigQuery.
+These permissions allow both the Worker and API Service Accounts to query and read data from your Drive inventory report in BigQuery. The helper script provides the most accurate commands based on your specific configuration.
 </walkthrough-footnote>
 
-<!-- #################### FINAL STEP #################### -->
 <!-- #################### FINAL STEP #################### -->
 
 ## Congratulations!

--- a/steps/07_grant_bigquery_permissions.sh
+++ b/steps/07_grant_bigquery_permissions.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script helps grant BigQuery permissions to Sync to Cloud service accounts
+# It provides the exact gcloud commands needed to grant access in the BigQuery project
+
+# Exit on error
+set -e
+
+# Source common utilities and environment variables
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/utils.sh"
+source "${SCRIPT_DIR}/env.sh"
+
+# Display banner
+display_banner "BigQuery Access Configuration" "Grant BigQuery permissions to Sync to Cloud service accounts"
+
+# Check required commands
+check_command "gcloud"
+
+# Get project details from argument or from gcloud config
+PROJECT_ID=$(get_project_id "$1")
+
+log_info "Sync to Cloud Project ID: ${COLOR_BOLD}${PROJECT_ID}${COLOR_RESET}"
+
+# Define service accounts
+WORKER_SA="sa-sync-to-cloud-worker@${PROJECT_ID}.iam.gserviceaccount.com"
+API_SA="sa-sync-to-cloud-api@${PROJECT_ID}.iam.gserviceaccount.com"
+
+log_info "Worker Service Account: ${COLOR_BOLD}${WORKER_SA}${COLOR_RESET}"
+log_info "API Service Account: ${COLOR_BOLD}${API_SA}${COLOR_RESET}"
+
+# Get BigQuery project information from terraform.tfvars if available
+BQ_PROJECT_ID=""
+BQ_DATASET=""
+BQ_TABLE=""
+
+if [[ -f "terraform.tfvars" ]]; then
+  log_info "Reading BigQuery configuration from terraform.tfvars..."
+  
+  # Extract BigQuery configuration
+  BQ_PROJECT_ID=$(grep "^bigquery_project_id" terraform.tfvars | cut -d'"' -f2 2>/dev/null || echo "")
+  BQ_DATASET=$(grep "^bigquery_dataset" terraform.tfvars | cut -d'"' -f2 2>/dev/null || echo "")
+  BQ_TABLE=$(grep "^bigquery_table" terraform.tfvars | cut -d'"' -f2 2>/dev/null || echo "")
+  
+  if [[ -n "$BQ_PROJECT_ID" ]]; then
+    log_success "Found BigQuery configuration:"
+    log_info "  BigQuery Project ID: ${COLOR_BOLD}${BQ_PROJECT_ID}${COLOR_RESET}"
+    log_info "  BigQuery Dataset: ${COLOR_BOLD}${BQ_DATASET}${COLOR_RESET}"
+    log_info "  BigQuery Table: ${COLOR_BOLD}${BQ_TABLE}${COLOR_RESET}"
+  fi
+else
+  log_warning "terraform.tfvars not found. You'll need to provide BigQuery project information manually."
+fi
+
+# Ask for BigQuery project if not found
+if [[ -z "$BQ_PROJECT_ID" ]]; then
+  echo ""
+  BQ_PROJECT_ID=$(ask_required "Enter your BigQuery project ID: " "BigQuery project ID is required.")
+  log_success "BigQuery project ID set to: ${COLOR_BOLD}${BQ_PROJECT_ID}${COLOR_RESET}"
+fi
+
+echo ""
+log_step "BigQuery Permission Commands"
+log_info "You need to run the following commands to grant BigQuery permissions."
+log_info "These commands should be run in the context of your BigQuery project: ${COLOR_BOLD}${BQ_PROJECT_ID}${COLOR_RESET}"
+
+echo ""
+log_info "${COLOR_BOLD}Option 1: Grant permissions at PROJECT level${COLOR_RESET}"
+echo ""
+echo "# Set the BigQuery project as active"
+echo "gcloud config set project ${BQ_PROJECT_ID}"
+echo ""
+echo "# Grant BigQuery Job User role to Worker Service Account"
+echo "gcloud projects add-iam-policy-binding ${BQ_PROJECT_ID} \\"
+echo "  --member=\"serviceAccount:${WORKER_SA}\" \\"
+echo "  --role=\"roles/bigquery.jobUser\""
+echo ""
+echo "# Grant BigQuery Data Viewer role to Worker Service Account"
+echo "gcloud projects add-iam-policy-binding ${BQ_PROJECT_ID} \\"
+echo "  --member=\"serviceAccount:${WORKER_SA}\" \\"
+echo "  --role=\"roles/bigquery.dataViewer\""
+echo ""
+echo "# Grant BigQuery Job User role to API Service Account"
+echo "gcloud projects add-iam-policy-binding ${BQ_PROJECT_ID} \\"
+echo "  --member=\"serviceAccount:${API_SA}\" \\"
+echo "  --role=\"roles/bigquery.jobUser\""
+echo ""
+echo "# Grant BigQuery Data Viewer role to API Service Account"
+echo "gcloud projects add-iam-policy-binding ${BQ_PROJECT_ID} \\"
+echo "  --member=\"serviceAccount:${API_SA}\" \\"
+echo "  --role=\"roles/bigquery.dataViewer\""
+
+if [[ -n "$BQ_DATASET" ]]; then
+  echo ""
+  log_info "${COLOR_BOLD}Option 2: Grant permissions at DATASET level (more restrictive)${COLOR_RESET}"
+  echo ""
+  echo "# Set the BigQuery project as active"
+  echo "gcloud config set project ${BQ_PROJECT_ID}"
+  echo ""
+  echo "# Grant BigQuery Job User role to Worker Service Account (must be at project level)"
+  echo "gcloud projects add-iam-policy-binding ${BQ_PROJECT_ID} \\"
+  echo "  --member=\"serviceAccount:${WORKER_SA}\" \\"
+  echo "  --role=\"roles/bigquery.jobUser\""
+  echo ""
+  echo "# Grant BigQuery Job User role to API Service Account (must be at project level)"
+  echo "gcloud projects add-iam-policy-binding ${BQ_PROJECT_ID} \\"
+  echo "  --member=\"serviceAccount:${API_SA}\" \\"
+  echo "  --role=\"roles/bigquery.jobUser\""
+  echo ""
+  echo "# Grant BigQuery Data Viewer role to Worker Service Account at dataset level"
+  echo "bq add-iam-policy-binding \\"
+  echo "  --member=\"serviceAccount:${WORKER_SA}\" \\"
+  echo "  --role=\"roles/bigquery.dataViewer\" \\"
+  echo "  ${BQ_PROJECT_ID}:${BQ_DATASET}"
+  echo ""
+  echo "# Grant BigQuery Data Viewer role to API Service Account at dataset level"
+  echo "bq add-iam-policy-binding \\"
+  echo "  --member=\"serviceAccount:${API_SA}\" \\"
+  echo "  --role=\"roles/bigquery.dataViewer\" \\"
+  echo "  ${BQ_PROJECT_ID}:${BQ_DATASET}"
+fi
+
+echo ""
+log_step "Next Steps"
+log_info "1. Copy and run the commands above in your terminal"
+log_info "2. Make sure you're authenticated with sufficient permissions in the BigQuery project"
+log_info "3. Choose either project-level or dataset-level permissions based on your security requirements"
+log_info "4. Verify the permissions were granted successfully"
+
+echo ""
+log_success "BigQuery access configuration commands generated successfully!"
+log_info "After running these commands, your Sync to Cloud service accounts will have access to query your Drive inventory data."


### PR DESCRIPTION
This pull request updates the `cloudshell_tutorial.md` to improve clarity and streamline the process for granting BigQuery permissions to service accounts, and it introduces a new helper script to automate this step. The tutorial steps have been reorganized and clarified, and now recommend using a script to generate the required permission commands, reducing manual errors and improving user experience.